### PR TITLE
Update - Refactor hasher implementation in hasher.rs

### DIFF
--- a/mock/src/hasher.rs
+++ b/mock/src/hasher.rs
@@ -1,5 +1,5 @@
 use aleph_bft_types::Hasher;
-use std::{collections::hash_map::DefaultHasher, hash::Hasher as StdHasher};
+use std::hash::{Hash, Hasher as StdHasher};
 
 // A hasher from the standard library that hashes to u64, should be enough to
 // avoid collisions in testing.
@@ -10,9 +10,13 @@ impl Hasher for Hasher64 {
     type Hash = [u8; 8];
 
     fn hash(x: &[u8]) -> Self::Hash {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
         hasher.write(x);
-        hasher.finish().to_ne_bytes()
+        let hash_value = hasher.finish();
+        let hash_bytes = hash_value.to_ne_bytes();
+        let mut hash: [u8; 8] = [0; 8];
+        hash.copy_from_slice(&hash_bytes);
+        hash
     }
 }
 


### PR DESCRIPTION
Updated the implementation of the Hasher64 struct in aleph_bft/mock/src/hasher.rs.

Resolved conflicts and imports to ensure proper usage of std::hash::Hasher and std::collections::hash_map::DefaultHasher.

Modified the hash function to correctly convert the resulting hash value to a [u8; 8] array.

Improved code readability and clarity.