### PR TITLE
Fix Typos in Code and Documentation

### DIFF
--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -104,7 +104,7 @@ impl<U: UnitWithParents> CandidateElection<U> {
         let relative_round = voter.round() - self.round;
         let vote = match relative_round {
             0 => unreachable!("just checked that voter and election rounds are not equal"),
-            // Direct descendands vote for, all other units of that round against.
+            // Direct descendants vote for, all other units of that round against.
             1 => voter.parent_for(self.candidate_creator) == Some(&self.candidate_hash),
             // Otherwise we compute the vote based on the parents' votes.
             _ => {

--- a/consensus/src/terminator.rs
+++ b/consensus/src/terminator.rs
@@ -80,7 +80,7 @@ impl Terminator {
         if !self.parent_exit.is_terminated() {
             debug!(
                 target: self.component_name,
-                "Terminator has not recieved exit from parent: synchronization canceled.",
+                "Terminator has not received exit from parent: synchronization canceled.",
             );
             return;
         }
@@ -104,7 +104,7 @@ impl Terminator {
             offspring_receivers.push((receiver, name));
         }
 
-        // Make sure that all descendants recieved exit and won't be communicating with other components
+        // Make sure that all descendants received exit and won't be communicating with other components
         for (receiver, name) in offspring_receivers {
             if receiver.await.is_err() {
                 debug!(
@@ -143,7 +143,7 @@ impl Terminator {
             } else {
                 debug!(
                     target: self.component_name,
-                    "Terminator recieved shutdown permission from parent component."
+                    "Terminator received shutdown permission from parent component."
                 );
             }
         }

--- a/docs/src/aleph_bft_api.md
+++ b/docs/src/aleph_bft_api.md
@@ -77,7 +77,7 @@ These traits are optional. If you do not want to recover crashes mid session or 
 
 [`std::io::Write`](https://doc.rust-lang.org/std/io/trait.Write.html#) should provide a way of writing data generated during session which should be backed up. **`flush` method should block until the written data is backed up.**
 
-[`std::io::Read`](https://doc.rust-lang.org/std/io/trait.Read.html#) should provide a way of retreiving backups of all data generated during session by this member in case of crash. **`std::io::Read` should have a copy of all data so that writing to `std::io::Write` has no effect on reading.**
+[`std::io::Read`](https://doc.rust-lang.org/std/io/trait.Read.html#) should provide a way of retrieving backups of all data generated during session by this member in case of crash. **`std::io::Read` should have a copy of all data so that writing to `std::io::Write` has no effect on reading.**
 
 ### 3.2 Examples
 

--- a/docs/src/how_alephbft_does_it.md
+++ b/docs/src/how_alephbft_does_it.md
@@ -199,7 +199,7 @@ The main idea here is that we cannot afford to store an arbitrary amount of unit
 
 **`ForkAlert(sender, forker, proof, units)`**
 
-where `sender` is the node index of the sender, `forker` is the node index of a forking node, `proof` is a pair of units created by forker that constitute a fork and `units` is simply some list of forker's units. Such a message is brodcast by `sender` to all other nodes:
+where `sender` is the node index of the sender, `forker` is the node index of a forking node, `proof` is a pair of units created by forker that constitute a fork and `units` is simply some list of forker's units. Such a message is broadcast by `sender` to all other nodes:
 
 1. The broadcast is performed using a **Reliable Broadcast** primitive. Roughly speaking, this means that the node does not simply multicast this message to all the nodes but runs a specialized protocol that guarantees that all the nodes receive this message (if the sender is honest) and receive the exact same version of this message (even if the sender is **dishonest**). We give more details on the AlephBFT's implementation of reliable broadcast in the [Reliable Broadcast](reliable_broadcast.md##6-reliable-broadcast) section.
 2. The intuitive meaning of such an alert is that: "I, `sender`, am aware that `forker` forked and I attach a `proof` of that. Moreover, before I realized this fact, I accepted the following list of units from `forker` to my local copy of the Dag. Please accept these units as well."

--- a/examples/blockchain/src/network.rs
+++ b/examples/blockchain/src/network.rs
@@ -173,7 +173,7 @@ impl NetworkManager {
 
     fn reset_dns(&mut self, n: &NodeIndex) {
         if !self.bootnodes.contains(n) {
-            error!("Reseting address of node {}", n.0);
+            error!("Resetting address of node {}", n.0);
             self.addresses.remove(n);
         }
     }


### PR DESCRIPTION


**Description:**
This pull request addresses several typographical errors in both the codebase and documentation. The changes include:

1. **Code Corrections:**
   - Corrected spelling of "descendants" in `consensus/src/extension/election.rs`.
   - Fixed "received" spelling in multiple locations within `consensus/src/terminator.rs`.

2. **Documentation Updates:**
   - Corrected "retrieving" spelling in `docs/src/aleph_bft_api.md`.
   - Fixed "broadcast" spelling in `docs/src/how_alephbft_does_it.md`.

3. **Log Message Fix:**
   - Corrected log message spelling in `examples/blockchain/src/network.rs`.

These changes improve the readability and professionalism of the code and documentation.
